### PR TITLE
Add terminal Snake game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
 # hekk
 first depot
-yooooooo 
+yooooooo
 i love pizza
+
+## Snake Game
+
+A simple terminal Snake game using Python and the `curses` library is provided in `snake.py`.
+
+Run it with:
+
+```bash
+python3 snake.py
+```
+
+Use the arrow keys to control the snake. Eating food increases your score. Colliding with the wall or your own tail ends the game.

--- a/snake.py
+++ b/snake.py
@@ -1,0 +1,74 @@
+import curses
+from curses import KEY_RIGHT, KEY_LEFT, KEY_UP, KEY_DOWN
+from random import randint
+
+
+def main(stdscr):
+    curses.curs_set(0)
+    sh, sw = stdscr.getmaxyx()
+    w = curses.newwin(sh, sw, 0, 0)
+    w.keypad(1)
+    w.timeout(100)
+
+    snk_x = sw // 4
+    snk_y = sh // 2
+    snake = [
+        [snk_y, snk_x],
+        [snk_y, snk_x - 1],
+        [snk_y, snk_x - 2],
+    ]
+    food = [sh // 2, sw // 2]
+    w.addch(food[0], food[1], curses.ACS_PI)
+
+    key = KEY_RIGHT
+    score = 0
+
+    while True:
+        next_key = w.getch()
+        if next_key != -1:
+            key = next_key
+
+        if key == KEY_RIGHT:
+            new_head = [snake[0][0], snake[0][1] + 1]
+        elif key == KEY_LEFT:
+            new_head = [snake[0][0], snake[0][1] - 1]
+        elif key == KEY_UP:
+            new_head = [snake[0][0] - 1, snake[0][1]]
+        elif key == KEY_DOWN:
+            new_head = [snake[0][0] + 1, snake[0][1]]
+        else:
+            continue
+
+        snake.insert(0, new_head)
+
+        if (
+            snake[0][0] in [0, sh] or
+            snake[0][1] in [0, sw] or
+            snake[0] in snake[1:]
+        ):
+            msg = "Game Over!"
+            w.addstr(sh // 2, sw // 2 - len(msg) // 2, msg)
+            w.refresh()
+            curses.napms(2000)
+            break
+
+        if snake[0] == food:
+            score += 1
+            food = None
+            while food is None:
+                nf = [randint(1, sh - 2), randint(1, sw - 2)]
+                food = nf if nf not in snake else None
+            w.addch(food[0], food[1], curses.ACS_PI)
+        else:
+            tail = snake.pop()
+            w.addch(tail[0], tail[1], ' ')
+
+        w.addch(snake[0][0], snake[0][1], '#')
+
+    w.addstr(sh - 1, 0, f"Score: {score}  Press any key to exit.")
+    w.timeout(-1)
+    w.getch()
+
+
+if __name__ == "__main__":
+    curses.wrapper(main)


### PR DESCRIPTION
## Summary
- add a simple terminal Snake game in `snake.py`
- document how to run the Snake game in README

## Testing
- `python3 snake.py` *(fails: curses app cannot run in non-interactive environment)*

------
https://chatgpt.com/codex/tasks/task_e_68519293d874832f88effbfe74e8fbd8